### PR TITLE
Tweaking showTime and showTimeLeft conditionals

### DIFF
--- a/module/audio.coffee
+++ b/module/audio.coffee
@@ -157,8 +157,9 @@ class exports.AudioPlayer extends Layer
 			@progressBar.on "change:value", =>
 				@player.currentTime = @progressBar.value
 
-				if @time and @timeLeft
+				if @time
 					@time.html = @player.formatTime()
+				if @timeLeft
 					@timeLeft.html = "-" + @player.formatTimeLeft()
 
 			@progressBar.knob.on Events.DragMove, => isMoving = true
@@ -183,8 +184,9 @@ class exports.AudioPlayer extends Layer
 					@progressBar.knob.midX = @progressBar.pointForValue(@player.currentTime)
 					@progressBar.knob.draggable.isMoving = false
 
-				if @time and @timeLeft
+				if @time
 					@time.html = @player.formatTime()
+				if @timeLeft
 					@timeLeft.html = "-" + @player.formatTimeLeft()
 
 	setVolume: (showVolume) ->


### PR DESCRIPTION
Was using `audio.showTime = true` as well as `audio.showProgress = true` in a project and ran into the issue where the `currentTime` display would not update accordingly, but the progress bar fill did. 

Hopefully this should allow enabling either `audio.showTime`, `audio.showTimeLeft`, or both when `audio.showProgress` is also enabled.
