### PR TITLE
Update AudioPlayer module to work nicely with latest Framer

### DIFF
--- a/module/audio.coffee
+++ b/module/audio.coffee
@@ -154,8 +154,10 @@ class exports.AudioPlayer extends Layer
 			wasPlaying = isMoving = false
 			unless @player.paused then wasPlaying = true
 
-			@progressBar.on "change:value", =>
-				@player.currentTime = @progressBar.value
+			@progressBar.on Events.SliderValueChange, =>
+				currentTime = Math.round(@player.currentTime)
+				progressBarTime = Math.round(@progressBar.value)
+				@player.currentTime = @progressBar.value unless currentTime == progressBarTime
 
 				if @time and @timeLeft
 					@time.html = @player.formatTime()


### PR DESCRIPTION
Add extra check on SliderValueChange to prevents timeupdates from resetting the currentTime (causing stutter)

This change is necessary because FramerJS now emits changes also if you change the slider programmatically.
